### PR TITLE
Close two arbitrary-code-execution paths in load_residuals (pickle + eval)

### DIFF
--- a/src/residual_analysis.py
+++ b/src/residual_analysis.py
@@ -1,3 +1,4 @@
+import ast
 import numpy as np
 import os
 
@@ -203,7 +204,10 @@ def load_residuals(filepath):
     try:
         # Assuming NPZ format for now
         if filepath.lower().endswith('.npz'):
-            data = np.load(filepath, allow_pickle=True) # Allow pickle for metadata potentially
+            # allow_pickle=False: refuse arbitrary object deserialization. A crafted .npz
+            # can embed a pickle payload that executes code on load; the residual arrays and
+            # the metadata string below do not need pickle, so disabling it is safe here.
+            data = np.load(filepath, allow_pickle=False)
             times = data.get('times_years')
             pos_residuals = data.get('position_residuals_au')
             vel_residuals = data.get('velocity_residuals_au_day')
@@ -212,7 +216,11 @@ def load_residuals(filepath):
                  try:
                      # Attempt to parse the metadata string back into a dict
                      metadata_str = str(data['metadata'].item()) # Extract string from array
-                     metadata = eval(metadata_str) # Use eval carefully! Assumes trusted source.
+                     # ast.literal_eval parses Python literals only (dict/list/str/num/etc.)
+                     # and never executes code, unlike eval(). A malicious metadata string
+                     # therefore cannot run arbitrary code; non-literal input raises and is
+                     # caught below, degrading to the raw string.
+                     metadata = ast.literal_eval(metadata_str)
                  except Exception as meta_e:
                      print(f"Warning: Could not parse metadata from file: {meta_e}")
                      metadata = {'raw_metadata': str(data['metadata'])} # Store raw string


### PR DESCRIPTION
## Draft: harden `load_residuals` against malicious `.npz` files

`src/residual_analysis.py::load_residuals` had two arbitrary-code-execution paths reachable by anyone who can hand the program a `.npz` file.

### Finding 1 (reported externally, with a working PoV) - pickle deserialization
```python
data = np.load(filepath, allow_pickle=True)  # Allow pickle for metadata potentially
```
`allow_pickle=True` re-enables NumPy's pickle path, which executes arbitrary code during deserialization (CWE-502). A crafted `.npz` embedding a pickle payload runs on load.

### Finding 2 (found while fixing 1) - eval on file contents
```python
metadata = eval(metadata_str)  # Use eval carefully! Assumes trusted source.
```
The metadata string comes straight from the file and is passed to `eval()` (CWE-95). This is a second code-exec path that survives even after pickle is disabled.

### Fix
- `allow_pickle=False`. The residual arrays are plain floats and the metadata is a string, so nothing that is loaded needs pickle. Behavior-safe.
- `ast.literal_eval` replaces `eval` for the metadata string. It parses Python literals only and never executes code. Non-literal input raises and is caught by the existing handler, degrading to the `raw_metadata` string fallback.

### Verification
Smoke-tested locally:
- A valid `.npz` still loads: metadata parses to a `dict`, all three arrays intact.
- A `.npz` whose `metadata` is `__import__('os').system(...)` no longer executes; it falls back to `{'raw_metadata': ...}` with no side effect.

### Status
Draft, held for review rather than self-merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security of residual file loading by preventing potential arbitrary code execution vulnerabilities when processing residual analysis data from external sources. Enhanced validation mechanisms for residual file metadata to ensure safer data handling while maintaining complete backward compatibility with existing residual analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->